### PR TITLE
Fix AtomPub Basic auth always returning 401 (NPE on null this.user)

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/webservices/atomprotocol/RollerAtomHandler.java
+++ b/app/src/main/java/org/apache/roller/weblogger/webservices/atomprotocol/RollerAtomHandler.java
@@ -478,7 +478,7 @@ public class RollerAtomHandler implements AtomHandler {
                             User inUser = roller.getUserManager().getUserByUserName(userID);
                             if (inUser.getEnabled()) {
                                 String password = userPass.substring(p+1);
-                                valid = RollerContext.getPasswordEncoder().matches(password, user.getPassword());
+                                valid = RollerContext.getPasswordEncoder().matches(password, inUser.getPassword());
                             }
                         }
                     }


### PR DESCRIPTION
## Problem
`RollerAtomHandler.authenticateBASIC()` always fails, so AtomPub clients get HTTP 401 with any credentials.

The constructor calls `authenticateBASIC(request)` and only assigns `this.user` *afterward*. But `authenticateBASIC` checks the password against the instance field `user.getPassword()` — which is still `null` at that point. The resulting NPE is swallowed by the `catch (Exception e) { log.debug(...) }`, so auth silently returns null → 401 for everyone. (The debug log is also invisible in our deploy because log4j2 isn't configured for DEBUG.)

## Fix
Use the local `inUser` (already looked up on line 478 and used for `getEnabled()` on line 479) instead of the null field. This matches the correct pattern already used in the sibling `authenticateWSSE()`.

```diff
-  valid = RollerContext.getPasswordEncoder().matches(password, user.getPassword());
+  valid = RollerContext.getPasswordEncoder().matches(password, inUser.getPassword());
```

## Notes
- Confirmed against the deployed 6.1.5 bytecode; same bug exists in upstream apache/roller 6.1.4/6.1.6/master — worth upstreaming separately.
- Verified out-of-band that the target user exists, is enabled, and the supplied password bcrypt-matches the stored hash; the only failure was this NPE.